### PR TITLE
Feature/expenses type request

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 openai
 aiogram
-dotenv
+python-dotenv
+Flask==3.1.1
+requests==2.32.0

--- a/src/main.py
+++ b/src/main.py
@@ -11,11 +11,14 @@ from aiogram.enums import ParseMode
 from aiogram.filters import Command 
 from aiogram.types import Message
 from openai import AsyncOpenAI
+import requests
 
 load_dotenv()
 
 # Set your bot and AI token here or use an environment variable
 BOT_TOKEN = os.getenv("TELEGRAM_API_KEY")
+
+URL_LITEFARM = os.getenv("URL_LITEFARM")
 
 if not BOT_TOKEN:
     raise ValueError("Please set the TELEGRAM_API_KEY environment variable.")
@@ -42,18 +45,31 @@ client = AsyncOpenAI(
 dp = Dispatcher()
 
 # --- Deepseek consulting function ---
-async def query_ai_model(user_message: str) -> str:
+async def query_ai_model(user_message: str, expense_type: list) -> str:
     try:
-
+        # Format expense types to be more readable for the AI
+        formatted_expense_types = []
+        if expense_type:
+            for item in expense_type:
+                if isinstance(item, dict):
+                    expense_id = item.get('expense_type_id', '')
+                    name = item.get('expense_name', '')
+                    if expense_id and name:
+                        formatted_expense_types.append(f"{expense_id}: {name}")
+            
+        expense_context = "Expense types available:\n" + "\n".join(formatted_expense_types) if formatted_expense_types else "No expense types available"
+        
         messages = [
             {"role": "system", "content": FINANCIAL_CLASSIFIER_PROMPT},
+            {"role": "system", "content": expense_context},
+            {"role": "system", "content": "When user reports an expense, select the most appropriate expense type ID from the list above."},
             {"role": "user", "content": user_message},
         ]
 
         response = await client.chat.completions.create(
             model=MODEL_NAME,
             messages=messages,
-            max_tokens=100,
+            max_tokens=150,
             temperature=0.3,
         )
 
@@ -71,6 +87,18 @@ async def handle_api_transaction(api_response: json):
     type_ = api_response.get("type")
 
     logging.info(f"API Transaction: Note: {note}, Value: {value}, Type: {type_}")
+
+async def request_expense_types():
+    try:
+        response = requests.get(f"{URL_LITEFARM}/expense_type/all")
+        if response.status_code == 200:
+            return response.json()
+        else:
+            logging.error(f"Error fetching expense types: {response.status_code}")
+            return []
+    except requests.RequestException as e:
+        logging.error(f"Request error: {e}")
+        return []
 
 @dp.message(Command("start"))
 async def cmd_start(message: Message):
@@ -126,7 +154,9 @@ async def handle_regular_message(message: Message):
         await message.answer("⚠️ El mensaje está vacío. Por favor, escribe algo para que pueda ayudarte.")
         return
 
-    response_text = await query_ai_model(user_input)
+    expense_type = await request_expense_types()
+
+    response_text = await query_ai_model(user_input, expense_type)
 
     try:
         data = json.loads(response_text)
@@ -135,6 +165,36 @@ async def handle_regular_message(message: Message):
         respuesta = data.get("respuesta")
         api_response = data.get("respuesta_api", {"note": "", "value": "", "type": ""})
 
+        # When an expense is detected, show available expense types
+        if clasificacion == "gasto":
+            # Format expense types for user display
+            expense_options = []
+            if expense_type:
+                for item in expense_type:
+                    if isinstance(item, dict):
+                        expense_id = item.get('expense_type_id', '')
+                        name = item.get('expense_name', '')
+                        if expense_id and name:
+                            expense_options.append(f"• {name} (ID: {expense_id})")
+            
+            # If there are expense types available, suggest a selected one
+            if expense_options and api_response.get("type"):
+                selected_type = api_response.get("type")
+                selected_name = ""
+                
+                # Find the name of the selected expense type
+                for item in expense_type:
+                    if isinstance(item, dict) and str(item.get('expense_type_id', '')) == str(selected_type):
+                        selected_name = item.get('expense_name', '')
+                        break
+                
+                if not selected_name and selected_type:
+                    # If we couldn't find the ID in the list, maybe the AI sent the name directly
+                    selected_name = selected_type
+                
+                expense_list = "\n".join(expense_options)
+                respuesta = f"De los siguientes tipos de gastos:\n\n{expense_list}\n\nSeleccioné este tipo: {selected_name}\n\n{respuesta}"
+        
         if clasificacion == "no_relacionado":
             respuesta += "\n\nℹ️ Si necesitas ayuda, escribe /help para ver los comandos disponibles y ejemplos de uso."
             await message.answer(respuesta)

--- a/src/main.py
+++ b/src/main.py
@@ -92,13 +92,17 @@ async def request_expense_types():
     try:
         response = requests.get(f"{URL_LITEFARM}/expense_type/all")
         if response.status_code == 200:
-            return response.json()
+            data = response.json()
+            if not data:  # Check if response is empty
+                logging.error("Expense types response is empty")
+                return None
+            return data
         else:
             logging.error(f"Error fetching expense types: {response.status_code}")
-            return []
+            return None
     except requests.RequestException as e:
         logging.error(f"Request error: {e}")
-        return []
+        return None
 
 @dp.message(Command("start"))
 async def cmd_start(message: Message):
@@ -155,6 +159,11 @@ async def handle_regular_message(message: Message):
         return
 
     expense_type = await request_expense_types()
+    
+    # Check if there was an error getting expense types
+    if expense_type is None:
+        await message.answer("Hubo un error en el servidor obteninendo tipos de gastos, intentalo mas tarde.")
+        return
 
     response_text = await query_ai_model(user_input, expense_type)
 
@@ -175,7 +184,7 @@ async def handle_regular_message(message: Message):
                         expense_id = item.get('expense_type_id', '')
                         name = item.get('expense_name', '')
                         if expense_id and name:
-                            expense_options.append(f"• {name} (ID: {expense_id})")
+                            expense_options.append(f"• {name}")
             
             # If there are expense types available, suggest a selected one
             if expense_options and api_response.get("type"):

--- a/src/prompts.py
+++ b/src/prompts.py
@@ -15,7 +15,7 @@ Responde **exclusivamente** en el siguiente formato JSON, sin añadir texto adic
   "respuesta_api": {
     "note": "Descripción breve del mensaje del usuario",
     "value": "Monto numérico relacionado con el mensaje, o vacío si no aplica",
-    "type": "gasolina" | "maquinaria" | "plantas" | "otro"
+    "type": "ID o nombre del tipo de gasto seleccionado de la lista proporcionada en 'Expense types'"
   }
 }
 
@@ -36,4 +36,6 @@ Instrucciones adicionales:
 - La respuesta debe tener un máximo de 100 palabras.
 - No incluyas explicaciones ni justificaciones fuera del objeto JSON.
 - Siempre responde de manera positiva y útil.
+- Para gastos, selecciona el tipo de gasto (type) más apropiado de la lista proporcionada en 'Expense types'.
+- Si es posible, usa el ID del tipo de gasto para el campo 'type' en lugar del nombre.
 """


### PR DESCRIPTION
This pull request introduces functionality to fetch and utilize expense types from an external API, enhancing the bot's ability to classify user-reported expenses. Key changes include modifications to the AI query logic, integration of expense type retrieval, and updates to user messaging and prompts.

### Integration of Expense Types:
* Added a new environment variable `URL_LITEFARM` for the expense type API endpoint and implemented the `request_expense_types` function to fetch expense types from the API. Includes error handling for empty responses or request failures. (`src/main.py`, [[1]](diffhunk://#diff-2e5ad92c43aa96cc3a9cef6c6aec998b216f1379c43b1f651013d25e55989312R14-R22) [[2]](diffhunk://#diff-2e5ad92c43aa96cc3a9cef6c6aec998b216f1379c43b1f651013d25e55989312R91-R106)
* Updated the `query_ai_model` function to accept and format expense types, providing additional context to the AI for selecting appropriate expense type IDs. (`src/main.py`, [src/main.pyL45-R72](diffhunk://#diff-2e5ad92c43aa96cc3a9cef6c6aec998b216f1379c43b1f651013d25e55989312L45-R72))

### Enhancements to User Messaging:
* Modified the `handle_regular_message` function to fetch expense types before querying the AI. If fetching fails, the bot notifies the user of a server error. (`src/main.py`, [src/main.pyL129-R168](diffhunk://#diff-2e5ad92c43aa96cc3a9cef6c6aec998b216f1379c43b1f651013d25e55989312L129-R168))
* Enhanced the bot's response when an expense is detected by displaying available expense types and the selected type. Includes logic to resolve the selected type's name for user clarity. (`src/main.py`, [src/main.pyR177-R206](diffhunk://#diff-2e5ad92c43aa96cc3a9cef6c6aec998b216f1379c43b1f651013d25e55989312R177-R206))

### Updates to AI Prompts:
* Adjusted the AI prompt to instruct the model to select the most appropriate expense type from the provided list, prioritizing the use of IDs over names. (`src/prompts.py`, [[1]](diffhunk://#diff-76d2bd6a9a02e68756ea5d271423f201cb70ea401efcd402a49abf08555b6386L18-R18) [[2]](diffhunk://#diff-76d2bd6a9a02e68756ea5d271423f201cb70ea401efcd402a49abf08555b6386R39-R40)